### PR TITLE
Fix link visibility with correct Pico CSS variables

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "enabledPlugins": {
+    "pr-review-toolkit@claude-plugins-official": true,
+    "frontend-design@claude-plugins-official": true,
+    "feature-dev@claude-plugins-official": true,
+    "ralph-loop@claude-plugins-official": true,
+    "typescript-lsp@claude-plugins-official": true
+  }
+}

--- a/src/app.scss
+++ b/src/app.scss
@@ -46,8 +46,27 @@ body::before {
 	display: none;
 }
 
-nav a.active {
-	background-color: var(--primary-focus) !important;
+nav a {
+	color: var(--pico-primary-background);
+
+	&:hover {
+		color: var(--pico-primary-hover-background) !important;
+	}
+
+	&.active {
+		background-color: var(--pico-primary-focus) !important;
+	}
+}
+
+// Content links in bright orange
+main a,
+article a,
+section a {
+	color: var(--pico-primary-background);
+
+	&:hover {
+		color: var(--pico-primary-hover-background);
+	}
 }
 
 @media print {

--- a/src/lib/components/containers/Header.svelte
+++ b/src/lib/components/containers/Header.svelte
@@ -166,7 +166,7 @@
 		text-align: center;
 		padding: 0.5rem;
 		background: var(--pico-primary);
-		color: var(--pico-primary-inverse);
+		color: #fff;
 		border-radius: var(--pico-border-radius);
 		text-decoration: none;
 		font-weight: 600;


### PR DESCRIPTION
## Summary
- Use `--pico-primary-background` instead of undefined `--primary` variable for nav, main, article, and section links
- Improves contrast against the dark background with bright orange (#ff9500)
- Set download button text to white for better readability

## Test plan
- [ ] Verify navigation links are visible in the header
- [ ] Verify contact links (email, phone, Github, LinkedIn) are visible
- [ ] Verify content links in articles/sections are visible
- [ ] Verify download button has white text

🤖 Generated with [Claude Code](https://claude.com/claude-code)